### PR TITLE
add a sequential playback feature to the word list

### DIFF
--- a/client/src/components/WordList.jsx
+++ b/client/src/components/WordList.jsx
@@ -27,12 +27,53 @@ export default function WordList() {
     fetchWords();
    }, [setWords]);
 
+  // 連続再生機能
+  const playAllAudioAlternating = () => {
+    let index = 0;
+    let isEnglish = true; // 英語と日本語を交互に再生するフラグ
+  
+    const playNext = () => {
+      if (index < words.length) {
+        const audioBase64 = isEnglish
+          ? words[index].audioEnglish
+          : words[index].audioJapanese;
+        const audioBlob = base64ToBlob(audioBase64);
+        const audioUrl = URL.createObjectURL(audioBlob);
+        const audio = new Audio(audioUrl);
+  
+        audio.onended = () => {
+          if (isEnglish) {
+            isEnglish = false; // 次は日本語を再生
+          } else {
+            isEnglish = true;  // 次の単語の英語を再生
+            index++;           // 次の単語に進む
+          }
+          playNext();
+        };
+  
+        audio.play();
+      }
+    };
+  
+    playNext();
+  };
+
+  const base64ToBlob = (base64) => {
+    const binary = atob(base64);
+    const array = [];
+    for (let i = 0; i < binary.length; i++) {
+      array.push(binary.charCodeAt(i));
+    }
+    return new Blob([new Uint8Array(array)], { type: "audio/mp3" });
+  };
+
   if (loading) return <p>Loading words...</p>;
   if (error) return <p>{error}</p>;
 
   return (
     <div>
       <h2>Word List</h2>
+      <button onClick={playAllAudioAlternating}>Play All</button>
       {Array.isArray(words) && words.length > 0 ? (
         words.map((word) => <WordItem key={word.id} word={word} />)
       ) : (


### PR DESCRIPTION
### Description
This PR introduces a sequential playback feature to the app. When the Play All button is clicked, the feature reads aloud the registered English and Japanese phrases in sequence.

## Changes:
- Updated `WordItem.tsx` to include the Play All button and implement the sequential playback function.

Fixed #1