### PR TITLE
display words collection without user auth on the initial screen

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -75,10 +79,6 @@ button:focus-visible {
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -9,13 +9,15 @@ export default function Home() {
 
   return (
     <div>
-      <h1>myglish - remember words</h1>
+      <h1>myglish</h1>
       <AuthButton />
-      {user && (
+      {user ? (
         <>
           <WordForm />
           <WordList />
         </>
+      ) : (
+        <WordList />
       )}
     </div>
   );

--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -38,7 +38,9 @@ export const fetchWordsFromServer = async () => {
   try {
     const user = auth.currentUser;
     if (!user) {
-      throw new Error("User not logged in");
+      const response = await axios.get(`${API_BASE_URL}/api/words?public=true`);
+      console.log("Server response:", response.data); // レスポンスデータを確認
+      return response.data; // サーバーから取得した単語リスト
     }
     const idToken = await user.getIdToken();
 

--- a/server/src/routes/wordsManager.js
+++ b/server/src/routes/wordsManager.js
@@ -9,6 +9,18 @@ router.post("/words", wordsProcessAndSave);
 // Firestoreから単語リストを取得
 router.get("/words", async (req, res) => {
     try {
+      const { public: isPublic } = req.query; // クエリパラメータを取得
+
+      if (isPublic === "true") {
+        // パブリックデータを取得して返す
+        const publicWordsSnapshot = await db.collection("words").get();
+        const publicWords = publicWordsSnapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+        return res.json(publicWords); // パブリック単語を返す
+      }
+
       const authHeader = req.headers.authorization;
 
       if (!authHeader || !authHeader.startsWith("Bearer ")) {


### PR DESCRIPTION
### Description
This PR updates the initial screen to display the words collection without requiring user authentication.

## Changes:
- Updated `wordsManager.js` on the server side to access public data by handling a query parameter (`public=true`).

fixed #6